### PR TITLE
nginx: lwm2m: add proxy on port 5685 for CoAP server

### DIFF
--- a/nginx-lwm2m.conf
+++ b/nginx-lwm2m.conf
@@ -32,6 +32,14 @@ stream {
     }
 
     server {
+        listen  [::]:5685 udp;
+        listen  0.0.0.0:5685 udp;
+        proxy_connect_timeout 10s;
+        proxy_timeout 5m;
+        proxy_pass  gitci.com:5685;
+    }
+
+    server {
         listen  [::]:5686 udp;
         listen  0.0.0.0:5686 udp;
         proxy_connect_timeout 10s;


### PR DESCRIPTION
This allows a host to run Californium to host CoAP binaries for use
with the firmware download.

Signed-off-by: Michael Scott <michael.scott@linaro.org>