### PR TITLE
Unblock nginx when there is no internet connection

### DIFF
--- a/nginx-http-proxy.conf
+++ b/nginx-http-proxy.conf
@@ -14,7 +14,9 @@ http {
         listen  0.0.0.0:8080;
 
         location  /httpdc {
-            proxy_pass  https://device.iotpf.mb.softbank.jp;
+            resolver  8.8.8.8 valid=30s;
+            set  $softbank_iotpf device.iotpf.mb.softbank.jp;
+            proxy_pass  https://$softbank_iotpf;
         }
 
         location  /DEFAULT {

--- a/nginx-lwm2m.conf
+++ b/nginx-lwm2m.conf
@@ -44,6 +44,9 @@ stream {
         listen  0.0.0.0:5686 udp;
         proxy_connect_timeout 10s;
         proxy_timeout 5m;
-        proxy_pass  coaps-api.artik.cloud:5686;
+        # Fixed address used for coaps-api.artik.cloud to allow
+        # the container to run even when there is no network.
+        # TODO: find if there is a smarter/better way to workaround this
+        proxy_pass  23.22.72.29:5686;
     }
 }


### PR DESCRIPTION
Workarounds for being able to start the nginx server even when there is no valid/working dns server.